### PR TITLE
Fix calling deployCode at LinkToken.s.sol to run sandbox

### DIFF
--- a/script/sandbox/LinkToken.s.sol
+++ b/script/sandbox/LinkToken.s.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.6.2 <0.9.0;
 
 import "forge-std/Script.sol";
 import "src/interfaces/shared/LinkTokenInterface.sol";
+import "@chainlink/contracts/v0.8/shared/token/ERC677/LinkToken.sol";
 
 contract LinkTokenScript is Script {
   function run() external view {


### PR DESCRIPTION
`deployCode` and `getCode` explicitly require `import` the code now.
Otherwise, you will get the error message when you run `make fct-init` and `make fct-deploy-link-token`.

```
Error: script failed: vm.getCode: no matching artifact found
make[1]: *** [fct-deploy-link-token] Error 1
make: *** [fct-init] Error 2
```

So I explicitly add `import LinkToken.sol`.
