### PR TITLE
Fixing issue related to `vm.deployCode()` in sandbox scripts

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ test = 'test'
 libs = ['lib']
 via_ir = true
 solc_version = '0.8.19'
+unchecked_cheatcode_artifacts = true
 
 [profile.0_7_x]
 solc_version = '0.7.6'


### PR DESCRIPTION
This is a small fix to prevent errors when running `fct-init` and other commands that require the execution of sandbox scripts (and also tests I suspect).

I have added a `unchecked_cheatcode_artifacts = true` to the project's `foundry.toml`. 

The issue occurs because foundry now only fetches artifacts of contracts that are under `src` (more on this here: https://github.com/foundry-rs/foundry/issues/7569#issuecomment-2040317989). 